### PR TITLE
 Add fusemap for IMX6DQ SoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ driver and fusemap availability.
 | Vendor | Model    | Linux driver    | Read  | Write | Fusemap |
 |--------|----------|-----------------|-------|-------|---------|
 | NXP    | i.MX53   | nvmem-imx-iim   | yes   | no    | yes     |
-| NXP    | i.MX6Q   | nvmem-imx-ocotp | yes   | yes   | no      |
 | NXP    | i.MX6DL  | nvmem-imx-ocotp | yes   | yes   | yes     |
+| NXP    | i.MX6DQ  | nvmem-imx-ocotp | yes   | yes   | yes     |
 | NXP    | i.MX6SL  | nvmem-imx-ocotp | yes   | yes   | no      |
 | NXP    | i.MX6SLL | nvmem-imx-ocotp | yes   | yes   | no      |
 | NXP    | i.MX6SX  | nvmem-imx-ocotp | yes^  | yes   | no      |

--- a/fusemaps/IMX6DQ.yaml
+++ b/fusemaps/IMX6DQ.yaml
@@ -1,0 +1,366 @@
+---
+# crucible
+# One-Time-Programmable (OTP) fusing tool
+#
+# Copyright (c) F-Secure Corporation
+# Copyright (c) Foundries.io Ltd.
+#
+# Use of this source code is governed by the license
+# that can be found in the LICENSE file.
+
+# i.MX 6Dual/6Quad Applications Processor Reference Manual
+# iMX6DQRM Rev. 2, 06/2014
+#
+processor: IMX6DQ
+reference: 2
+
+driver: nvmem-imx-ocotp
+registers:
+  OCOTP_LOCK:
+    bank: 0
+    word: 0
+    fuses:
+      TESTER_LOCK:
+        offset: 0
+        len: 2
+      BOOT_CFG_LOCK:
+        offset: 2
+        len: 2
+      MEM_TRIM_LOCK:
+        offset: 4
+        len: 2
+      SJC_RESP_LOCK:
+        offset: 6
+        len: 1
+      MAC_ADDR_LOCK:
+        offset: 8
+        len: 2
+      GP1_LOCK:
+        offset: 10
+        len: 2
+      GP2_LOCK:
+        offset: 12
+        len: 2
+      SRK_LOCK:
+        offset: 14
+        len: 1
+      ANALOG_LOCK:
+        offset: 18
+        len: 2
+      MISC_CONF_LOCK:
+        offset: 22
+        len: 1
+
+  OCOTP_CFG0:
+    bank: 0
+    word: 1
+    fuses:
+      SJC_CHALLENGE:
+        offset: 0
+        len: 64
+      SJC_CHALLENGE[31:0]:
+        offset: 0
+        len: 32
+      UNIQUE_ID:
+        offset: 0
+        len: 64
+      UNIQUE_ID[31:0]:
+        offset: 0
+        len: 32
+      LOT_NO_ENC:
+        offset: 0
+        len: 43
+      LOT_NO_ENC[31:0]:
+        offset: 0
+        len: 32
+
+  OCOTP_CFG1:
+    bank: 0
+    word: 2
+    fuses:
+      SJC_CHALLENGE[63:32]:
+        offset: 0
+        len: 32
+      UNIQUE_ID[63:32]:
+        offset: 0
+        len: 32
+      LOT_NO_ENC[42:32]:
+        offset: 0
+        len: 11
+      WAFER_NO:
+        offset: 11
+        len: 5
+      DIE-Y-CORDINATE:
+        offset: 16
+        len: 8
+      DIE-X-CORDINATE:
+        offset: 24
+        len: 8
+
+  OCOTP_CFG2:
+    bank: 0
+    word: 3
+    fuses:
+      SI_REV:
+        offset: 16
+        len: 4
+      NUM_CORES:
+        offset: 20
+        len: 2
+      SATA_RST_SR:
+        offset: 24
+        len: 1
+
+  OCOTP_CFG3:
+    bank: 0
+    word: 4
+    fuses:
+      SPEED_GRADING:
+        offset: 16
+        len: 2
+
+  OCOTP_CFG4:
+    bank: 0
+    word: 5
+    fuses:
+      BOOT_CFG1:
+        offset: 0
+        len: 8
+      BOOT_CFG2:
+        offset: 8
+        len: 8
+      BOOT_CFG3:
+        offset: 16
+        len: 8
+      BOOT_CFG4:
+        offset: 24
+        len: 8
+
+  OCOTP_CFG5:
+    bank: 0
+    word: 6
+    fuses:
+      SEC_CONFIG:
+        offset: 1
+        len: 1
+      DIR_BT_DIS:
+        offset: 3
+        len: 1
+      BT_FUSE_SEL:
+        offset: 4
+        len: 1
+      DDR3_CONFIG:
+        offset: 8
+        len: 8
+      SJC_DISABLE:
+        offset: 20
+        len: 1
+      WDOG_ENABLE:
+        offset: 21
+        len: 1
+      JTAG_SMODE:
+        offset: 22
+        len: 2
+      KTE:
+        offset: 26
+        len: 1
+      JTAG_HEO:
+        offset: 27
+        len: 1
+      TZASC_ENABLE:
+        offset: 28
+        len: 1
+      SDMMC_HYS_EN:
+        offset: 29
+        len: 1
+      EMMC_RESET_EN:
+        offset: 30
+        len: 1
+
+  OCOTP_CFG6:
+    bank: 0
+    word: 7
+    fuses:
+      NAND_READ_CMD_CODE1:
+        offset: 0
+        len: 8
+      NAND_READ_CMD_CODE2:
+        offset: 8
+        len: 8
+      BT_LPB_POLARITY:
+        offset: 20
+        len: 1
+      LPB_BOOT:
+        offset: 21
+        len: 2
+      MMC_DLL_DLY:
+        offset: 24
+        len: 7
+
+  OCOTP_MEM0:
+    bank: 1
+    word: 0
+    fuses:
+      TEMPERATURE_GRADE:
+        offset: 6
+        len: 2
+  OCOTP_MEM1:
+    bank: 1
+    word: 1
+  OCOTP_MEM2:
+    bank: 1
+    word: 2
+  OCOTP_MEM3:
+    bank: 1
+    word: 3
+  OCOTP_MEM4:
+    bank: 1
+    word: 4
+
+  OCOTP_ANA0:
+    bank: 1
+    word: 5
+  OCOTP_ANA1:
+    bank: 1
+    word: 6
+  OCOTP_ANA2:
+    bank: 1
+    word: 7
+    fuses:
+      USB_VID:
+        offset: 0
+        len: 16
+      USB_PID:
+        offset: 16
+        len: 16
+
+  OCOTP_SRK0:
+    bank: 3
+    word: 0
+    fuses:
+      SRK_HASH:
+        offset: 0
+        len: 256
+      SRK_HASH[255:224]:
+        offset: 0
+        len: 32
+  OCOTP_SRK1:
+    bank: 3
+    word: 1
+    fuses:
+      SRK_HASH[223:192]:
+        offset: 0
+        len: 32
+  OCOTP_SRK2:
+    bank: 3
+    word: 2
+    fuses:
+      SRK_HASH[191:160]:
+        offset: 0
+        len: 32
+  OCOTP_SRK3:
+    bank: 3
+    word: 3
+    fuses:
+      SRK_HASH[159:128]:
+        offset: 0
+        len: 32
+  OCOTP_SRK4:
+    bank: 3
+    word: 4
+    fuses:
+      SRK_HASH[127:96]:
+        offset: 0
+        len: 32
+  OCOTP_SRK5:
+    bank: 3
+    word: 5
+    fuses:
+      SRK_HASH[95:64]:
+        offset: 0
+        len: 32
+  OCOTP_SRK6:
+    bank: 3
+    word: 6
+    fuses:
+      SRK_HASH[63:32]:
+        offset: 0
+        len: 32
+  OCOTP_SRK7:
+    bank: 3
+    word: 7
+    fuses:
+      SRK_HASH[31:0]:
+        offset: 0
+        len: 32
+
+  OCOTP_SJC_RESP0:
+    bank: 4
+    word: 0
+    fuses:
+      SJC_RESP:
+        offset: 0
+        len: 56
+      SJC_RESP[31:0]:
+        offset: 0
+        len: 32
+  OCOTP_SJC_RESP1:
+    bank: 4
+    word: 1
+    fuses:
+      SJC_RESP[55:32]:
+        offset: 0
+        len: 24
+
+  OCOTP_MAC0:
+    bank: 4
+    word: 2
+    fuses:
+      MAC1_ADDR:
+        offset: 0
+        len: 48
+      MAC1_ADDR[31:0]:
+        offset: 0
+        len: 32
+  OCOTP_MAC1:
+    bank: 4
+    word: 3
+    fuses:
+      MAC1_ADDR[47:32]:
+        offset: 0
+        len: 16
+
+  OCOTP_GP1:
+    bank: 4
+    word: 6
+    fuses:
+      GP1:
+        offset: 0
+        len: 32
+  OCOTP_GP2:
+    bank: 4
+    word: 7
+    fuses:
+      GP2:
+        offset: 0
+        len: 32
+
+  OCOTP_MISC_CONF:
+    bank: 5
+    word: 5
+    fuses:
+      PAD_SETTINGS:
+        offset: 0
+        len: 6
+
+  OCOTP_FIELD_RETURN:
+    bank: 5
+    word: 6
+    fuses:
+      FIELD_RETURN:
+        offset: 0
+        len: 1
+
+  OCOTP_SRK_REVOKE:
+    bank: 5
+    word: 7


### PR DESCRIPTION
Fusemap description from i.MX 6Dual/6Quad Applications Processor Reference Manual Rev. 2, 06/2014.